### PR TITLE
Add line to README explaining that this is a menu bar app

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ $ npm i
 $ npm start
 ```
 
+This launches the app and runs it in your menu bar.
+
 # packaging
 
 will be written to ./dist


### PR DESCRIPTION
As discussed in an issue stemming from my confusing of how the app was run (https://github.com/ipfs/electron-app/issues/39#issuecomment-139782596) I added a line explaining that this is a menu bar app. I guess down the road the README could explain any differences that other operating systems handle menu bar / tray applications.